### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN if [ "$NPM_TOKEN" ]; \
 # where available (npm@5+)
 COPY package*.json ./
 
-RUN npm install --production
+RUN npm install --production && npm cache clean --force;
 
 RUN rm -f .npmrc
 


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.


Impact on the image size:
* Image size before repair: 1.51 GB
* Image size after repair: 1.39 GB
* Difference: 119.71 MB (7.75%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,