### PR TITLE
refactor: derive database URIs from a single MONGODB_URI base

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,7 +1,26 @@
+function buildDbUri(baseUri, dbName) {
+  if (!baseUri) return baseUri;
+
+  const [head, query] = baseUri.split('?', 2);
+
+  const schemeIdx = head.indexOf('://');
+  if (schemeIdx === -1) return baseUri;
+
+  const pathIdx = head.indexOf('/', schemeIdx + 3);
+  const prefix = pathIdx === -1 ? head : head.slice(0, pathIdx);
+
+  const rebuilt = `${prefix}/${dbName}`;
+  return query ? `${rebuilt}?${query}` : rebuilt;
+}
+
+const DEFAULT_MAIN = 'mongodb://localhost:27017/tiledesk';
+const mainUri = process.env.MONGODB_URI || DEFAULT_MAIN;
+
 module.exports = {
-  secret:'nodeauthsecret',
-  schemaVersion: 2111, 
-  database: 'mongodb://localhost:27017/tiledesk',
-  databaselogs: 'mongodb://localhost:27017/tiledesk-logs',
-  databasetest: 'mongodb://localhost:27017/tiledesk-test'
+  buildDbUri,
+  secret: process.env.JWT_SECRET || 'nodeauthsecret',
+  schemaVersion: 2111,
+  database: mainUri,
+  databaselogs: process.env.MONGODB_URI_LOGS || buildDbUri(mainUri, 'tiledesk-logs'),
+  databasetest: process.env.MONGODB_URI_TEST || buildDbUri(mainUri, 'tiledesk-test')
 };

--- a/test/config/buildDbUri.test.js
+++ b/test/config/buildDbUri.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const { buildDbUri } = require('../../config/database');
+
+describe('buildDbUri', () => {
+
+  it('replaces the db name in a standard URI', () => {
+    const result = buildDbUri('mongodb://localhost:27017/tiledesk', 'tiledesk-logs');
+    assert.strictEqual(result, 'mongodb://localhost:27017/tiledesk-logs');
+  });
+
+  it('handles mongodb+srv with query params', () => {
+    const base = 'mongodb+srv://user:pass@cluster.example.com/mydb?retryWrites=true';
+    const result = buildDbUri(base, 'tiledesk-logs');
+    assert.strictEqual(result, 'mongodb+srv://user:pass@cluster.example.com/tiledesk-logs?retryWrites=true');
+  });
+
+  it('handles URI without a db path', () => {
+    const result = buildDbUri('mongodb://localhost:27017', 'tiledesk-logs');
+    assert.strictEqual(result, 'mongodb://localhost:27017/tiledesk-logs');
+  });
+
+  it('handles URI with auth credentials', () => {
+    const base = 'mongodb://admin:secret@host1:27017,host2:27017/proddb?authSource=admin';
+    const result = buildDbUri(base, 'tiledesk-logs');
+    assert.strictEqual(result, 'mongodb://admin:secret@host1:27017,host2:27017/tiledesk-logs?authSource=admin');
+  });
+
+  it('returns undefined when input is undefined', () => {
+    assert.strictEqual(buildDbUri(undefined, 'db'), undefined);
+  });
+
+  it('returns empty string when input is empty', () => {
+    assert.strictEqual(buildDbUri('', 'db'), '');
+  });
+
+  it('returns input unchanged when no scheme is found', () => {
+    assert.strictEqual(buildDbUri('not-a-uri', 'db'), 'not-a-uri');
+  });
+});


### PR DESCRIPTION
## What
Replaces hardcoded MongoDB connection strings in `config/database.js`
with a `buildDbUri` helper that derives `databaselogs` and `databasetest`
URIs from the primary connection string.

## Why
When deploying against a remote cluster (e.g. `mongodb+srv://`), the logs
and test databases still pointed at localhost unless their dedicated env
vars were set. This makes them automatically follow the primary URI.

## Backward compatibility
- No env vars set → same `localhost:27017` defaults as before
- `MONGODB_URI_LOGS` / `MONGODB_URI_TEST` remain optional overrides
- No changes to any consumers of `config.database`, `config.databaselogs`,
  or `config.databasetest`

## How to test

npx mocha test/config/buildDbUri.test.js

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change with small, well-tested string parsing; main risk is misconstructed URIs for uncommon MongoDB connection string formats.
> 
> **Overview**
> Refactors `config/database.js` to build `databaselogs` and `databasetest` URIs from the primary `MONGODB_URI` (falling back to the existing localhost default), instead of hardcoding separate localhost connection strings.
> 
> Adds a `buildDbUri()` helper that swaps/creates the database path while preserving query params, makes `secret` configurable via `JWT_SECRET`, and introduces Mocha tests covering common MongoDB URI formats and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 444c9fa0eba3aec4fcc4accf18ad50a1e2b52f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->